### PR TITLE
Fix BibTeX entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ If you use this code for your publication, please cite the original paper:
 ```
 @inproceedings{clark2019electra,
   title = {{ELECTRA}: Pre-training Text Encoders as Discriminators Rather Than Generators},
-  author = {Kevin Clark and Minh-Thang Luong and and Quoc V. Le and Christopher D. Manning},
+  author = {Kevin Clark and Minh-Thang Luong and Quoc V. Le and Christopher D. Manning},
   booktitle = {ICLR},
   year = {2020}
 }


### PR DESCRIPTION
When using the BibTeX entry in a LaTeX document, the following warning message appears:
```
BibTeX Name in key 'clark2019electra' is empty (probably consecutive 'and'): skipping name
```

This fixes the issue by removing a duplicated `and`.