### PR TITLE
pretraining: configure hparms for base and large models

### DIFF
--- a/configure_pretraining.py
+++ b/configure_pretraining.py
@@ -115,11 +115,14 @@ class PretrainingConfig(object):
     # paper for the full hyperparameters
     # else:
     #   self.max_seq_length = 512
-    #   self.learning_rate = 2e-5
+    #   self.learning_rate = 2e-4
     #   if self.model_size == "base":
+    #     self.embedding_size = 768
     #     self.generator_hidden_size = 0.33333
     #     self.train_batch_size = 256
     #   else:
+    #     self.embedding_size = 1024
+    #     self.mask_prob = 0.25
     #     self.train_batch_size = 2048
 
     # passed-in-arguments override (for example) debug-mode defaults


### PR DESCRIPTION
Hi,

this PR adjusts and adds some useful hyper-parameters to the `configure_pretraining.py` script.

One imporant fix is the learning rate for base/large models: originally 2e-5 was used and is now corrected to 2e-4, because this value is used in the paper.