### PR TITLE
Add keep_checkpoint_max parameter

### DIFF
--- a/configure_pretraining.py
+++ b/configure_pretraining.py
@@ -48,6 +48,8 @@ class PretrainingConfig(object):
     self.save_checkpoints_steps = 1000
     self.num_train_steps = 1000000
     self.num_eval_steps = 100
+    self.keep_checkpoint_max = 5 # maximum number of recent checkpoint files to keep;
+                                 # change to 0 or None to keep all checkpoints
 
     # model settings
     self.model_size = "small"  # one of "small", "base", or "large"

--- a/run_pretraining.py
+++ b/run_pretraining.py
@@ -328,6 +328,7 @@ def train_or_eval(config: configure_pretraining.PretrainingConfig):
       cluster=tpu_cluster_resolver,
       model_dir=config.model_dir,
       save_checkpoints_steps=config.save_checkpoints_steps,
+      keep_checkpoint_max=config.keep_checkpoint_max,
       tpu_config=tpu_config)
   model_fn = model_fn_builder(config=config)
   estimator = tf.estimator.tpu.TPUEstimator(


### PR DESCRIPTION
Hi,

this PR adds `keep_checkpoint_max` as new parameter to the [RunConfig](https://www.tensorflow.org/api_docs/python/tf/estimator/RunConfig) instance, in order to allow the user to specify the max. number of recent checkpoints to keep.

By default, only 5 checkpoints are kept. But this number can be quite low when evaluating own trained models, so the number of checkpoints to keep can be set now.