### PR TITLE
modified tfrecords_path split by / to accomodate windows path as well…

### DIFF
--- a/finetune/preprocessing.py
+++ b/finetune/preprocessing.py
@@ -78,7 +78,7 @@ class Preprocessor(object):
         examples += task_examples
       if is_training:
         random.shuffle(examples)
-      utils.mkdir(tfrecords_path.rsplit("/", 1)[0])
+      utils.mkdir(os.path.dirname(tfrecords_path))
       n_examples = self.serialize_examples(
           examples, is_training, tfrecords_path, batch_size)
       utils.write_json({"n_examples": n_examples}, metadata_path)


### PR DESCRIPTION
`utils.mkdir(tfrecords_path.rsplit("/", 1)[0])` this throws error while trying to save tfrecord file on windows machine as the path separator for windows is '\'. Made a simple change to accomodate windows as well. 
`utils.mkdir(os.path.dirname(tfrecords_path))`
