### PR TITLE
Fix dropout layer.

### DIFF
--- a/model/modeling.py
+++ b/model/modeling.py
@@ -364,8 +364,7 @@ def dropout(input_tensor, dropout_prob):
 
   Args:
     input_tensor: float Tensor.
-    dropout_prob: Python float. The probability of dropping out a value (NOT of
-      *keeping* a dimension as in `tf.nn.dropout`).
+    dropout_prob: Python float. The probability of dropping out a value.
 
   Returns:
     A version of `input_tensor` with dropout applied.
@@ -373,7 +372,7 @@ def dropout(input_tensor, dropout_prob):
   if dropout_prob is None or dropout_prob == 0.0:
     return input_tensor
 
-  output = tf.nn.dropout(input_tensor, 1.0 - dropout_prob)
+  output = tf.nn.dropout(input_tensor, dropout_prob)
   return output
 
 


### PR DESCRIPTION
The dropout layer states that `tf.nn.dropout` uses `rate` as the probability of keeping a dimension. But it is actually the probability of dropping a value. See https://www.tensorflow.org/api_docs/python/tf/nn/dropout - "With probability `rate` elements of x are set to `0`." So the keyword arguments concur and subtracting it from 1 will give incorrect results.
